### PR TITLE
Deleted public access block

### DIFF
--- a/lib/configure-s3-website/s3_client.rb
+++ b/lib/configure-s3-website/s3_client.rb
@@ -87,6 +87,9 @@ module ConfigureS3Website
     end
 
     def self.make_bucket_readable_to_everyone(config_source)
+      s3(config_source).delete_public_access_block({
+        bucket: config_source.s3_bucket_name
+      })
       s3(config_source).put_bucket_policy({
         bucket: config_source.s3_bucket_name,
         policy: %|{


### PR DESCRIPTION
Starting April 2023, Amazon has changed the default configuration for new S3 buckets and now S3 Block Public Access is enabled by default. To host a static website it's needed to turn off Block Public Access.